### PR TITLE
Fix configuration typo causing startup errors

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,4 +15,4 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.application.name=club-service
 eureka.client.service-url.defaultZone=http://localhost:8761/eureka
 eureka.client.register-with-eureka=true
-eureka.client.fetch-registry=true 
+eureka.client.fetch-registry=true


### PR DESCRIPTION
## Summary
- clean up `application.properties` to remove an accidental shell prompt

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ab0ded1a483219281a2f3f24e781b